### PR TITLE
Add starting documents for the 2019 Faro summit

### DIFF
--- a/faro2019/README.md
+++ b/faro2019/README.md
@@ -1,0 +1,7 @@
+# GMT Developer Summit in Faro 2019
+
+Planning documents and reports for the 2019 Faro summit.
+
+## Attendants
+
+TBD

--- a/faro2019/agenda.md
+++ b/faro2019/agenda.md
@@ -1,0 +1,6 @@
+# Agenda for the Faro 2019 summit
+
+First stab at a list of things that we want to discuss at the summit.
+
+* Onboarding documentation for getting new users involved in the project.
+* Place to ask questions once the GMT Wiki is retired.


### PR DESCRIPTION
We should try to populate the Agenda with things that we want to discuss and then trim and organize once there is enough stuff in there.

@GenericMappingTools/core notifying everyone that this exists. Please feel free to write down your ideas into the `faro2019/agenda.md` file (or create any new files in the `faro2019` folder).