### PR TITLE
Add steering committee members 2024

### DIFF
--- a/steering-committee-membership.md
+++ b/steering-committee-membership.md
@@ -1,5 +1,10 @@
 # Steering Committee Membership
 
-With the creation of a formal governance structure, the Generic Mapping Tools Steering
-Committee with be re-constituted with membership decided by active project developers
-and previous core developers in June 2024.
+The Generic Mapping Tools Steering Committee members are:
+- David Caress
+- Dongdong Tian
+- Federico Esteban
+- Joaqium Luis
+- Remko Scharroo
+- Walter Smith
+- Xiaohua (Eric) Xu


### PR DESCRIPTION
Following the nominations in #9 and their confirmation of interest via email, this PR re-constitutes the GMT Steering Committee with the members listed.

Closes #9 